### PR TITLE
add WJSmisc dep to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Suggests:
     spelling,
     testthat (>= 3.0.0),
     viridis,
-    quarto
+    quarto,
+    WJSmisc
 VignetteBuilder: 
     quarto
 Encoding: UTF-8
@@ -75,3 +76,4 @@ Collate:
     'inside.R'
     'rotate.R'
     'zzz.R'
+Remotes: wjschne/WJSmisc


### PR DESCRIPTION
I believe that this change would allow to install the WJSmisc dependency which is used in vignette examples, if the package is installed e.g. like this:
```r
remotes::install_github("wjschne/ggdiagram", dependencies = TRUE)
```